### PR TITLE
Monk X: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.4
+
+FROM golang:1.18-alpine AS builder
+
+WORKDIR /code
+
+ENV CGO_ENABLED 0
+ENV GOPATH /go
+ENV GOCACHE /go-build
+
+COPY . .
+
+RUN go mod init
+RUN go build -o /app/main ./main.go
+
+FROM alpine:3.15
+
+WORKDIR /app
+
+COPY --from=builder /app/main /app/main
+
+CMD ["/app/main"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO nginx-golang-mysql
+LOAD nginx-golang-mysql.yaml

--- a/nginx-golang-mysql.yaml
+++ b/nginx-golang-mysql.yaml
@@ -1,0 +1,56 @@
+namespace: nginx-golang-mysql
+nginx-golang-mysql:
+  defines: runnable
+  metadata:
+    name: nginx-golang-mysql
+    description: A blog application built with Nginx, Golang and MySQL.
+    icon: https://emojiapi.dev/api/v1/memo.svg
+  containers:
+    nginx-golang-mysql:
+      build: .
+      dockerfile: backend/Dockerfile
+  services:
+    backend:
+      container: nginx-golang-mysql
+      port: 8000
+      host-port: 8000
+      publish: false
+      protocol: TCP
+      description: The backend server listens on this port.
+    nginx:
+      container: nginx-golang-mysql
+      port: 80
+      host-port: 80
+      publish: false
+      protocol: TCP
+      description: The Nginx reverse proxy listens on this port.
+    db:
+      container: nginx-golang-mysql
+      port: 3306
+      host-port: 3306
+      publish: false
+      protocol: TCP
+      description: MySQL database service port.
+  connections:
+    mysql-db:
+      target: nginx-golang-mysql/db
+      service: monk-mysql-db
+  variables:
+    mysql-database:
+      env: MYSQL_DATABASE
+      type: string
+      description: The name of the MySQL database to connect to.
+      value: example
+    mysql-root-password-file:
+      env: MYSQL_ROOT_PASSWORD_FILE
+      type: string
+      description: Path to the file containing the root password for MySQL.
+      value: '!!!SETME-USE-SECRETS!!!'
+db:
+  defines: runnable
+  inherits: monk-mysql/db
+stack:
+  defines: group
+  members:
+    - nginx-golang-mysql/nginx-golang-mysql
+    - nginx-golang-mysql/db


### PR DESCRIPTION
I couldn't make the /tmp/ot2e6m/Dockerfile work and gave up. You can try to fix it yourself. Here's the error I get:


```
Start building image: 34.91.254.181/nginx-golang-mysql:main-0ee1edd
[1/2] STEP 1/8: FROM golang:1.18-alpine AS builder
[1/2] STEP 2/8: WORKDIR /code
--> Using cache 348da9b2b7682e77e5eaa0e322c37cf33dc3a4cc4043ba7b6957300af23a9739
--> 348da9b2b76
[1/2] STEP 3/8: ENV CGO_ENABLED 0
--> Using cache 2233f48eee353c95cc1fb8f11b60fa1b5b3039db3e96fb2ee7910da08b9e8892
--> 2233f48eee3
[1/2] STEP 4/8: ENV GOPATH /go
--> Using cache 913aa16022a123c07c3224b17375a6fafe4a9f333c2313429522b5d60b78e522
--> 913aa16022a
[1/2] STEP 5/8: ENV GOCACHE /go-build
--> Using cache d125a22a77d5408d2a9679bd0986dbeb2b6bb2e72215cd193c072eb0434efa7a
--> d125a22a77d
[1/2] STEP 6/8: COPY . .
--> 415ad840784
[1/2] STEP 7/8: RUN go mod init
Failed to build image: image service build failed
Error chain: 
↪ image service build failed
 ↪ new job and wait failed
   (description: , name: job.images.build)
   ↪ build image failed
     (image: 34.91.254.181/nginx-golang-mysql:main-0ee1edd)
     ↪ moby client build image: cmd wait failed
      ↪ go: cannot determine module path for source directory /code (outside GOPATH, module path must be specified)

Example usage:
	'go mod init example.com/m' to initialize a v0 or v1 module
	'go mod init example.com/m/v2' to initialize a v2 module

Run 'go help mod init' for more information.
Error: building at STEP "RUN go mod init": while running runtime: exit status 1

HINT If you did not expect this error, please share this code with Monk team:
      H4sIAAAAAAAC/7yT0U7bShCGX2W0NwRkbGzCUdg7DuIcWgmKgKoXmIu1PXEm3Z11d9cJFHHbh+lj9UmqdUILFLVc9SqKZ/5/vvnHvroT53bphby6EyfovWpRSEFGtQge3YJqhKon3cBUkcZGJOI/0rFnlDlrQ9Y5O8c6ZN3HNlsLfDbo/cP/tLVyXERlz3Ugyw8TfDraulj1bKb/ximbIhEnGFSjghJSiPvkMRZ8+/IVGJcwtxUobmCpKLwGbG4rn/WBtI8su5OdpzCxnJ7i8q2tDrj5oCg842jQ14662C4hAVYGZYRI12sMCT2HHWhX2a3yfAVopTw+pKdtS3U2GETqvb2n0EM5HW3NbXVoOShidC+nOPhJ2B2n+3la7I3TfJJn3BLfbLdWK263za3/pKVRxNs7iDk2vy4zbGNsdQu1JuTweDMJtXn9MaJJtjIZrlE8u0asp6Ot+HM4dK23ehNH/eEFWXO2VkKtmG2ABgM6Q4xgbNNrhE6FGUytA297VyM05LAO1t1CVtsGYWT74KlB+P/d2cHlcfJEZ3ofoELwHdY0JWw2Sy756EaZTiP0EUOWXIaN1kYdEFMAXJXT2prMbECww2NSmj4jKFjsgHWwyNeDfi/PFsULDsVPLZ/3DFE/Q939MNkYNjbWIRBPrTMqhp2WfOScdXJ1TOIWVICLy6MzKMX5+1N4hFEKCcsZaQTXM8dW13Og+CHgDQXwQYXeQ17yXzz+dSKOiYMXknutEzG0His/E1IsdtO8SKP9JRn0QZlOyPyf/UkxLibjyf319wAAAP//lON9LfsEAAA=


```

You can fix the error yourself, push to this branch and then merge the PR. Monk will import the kit ayutomatically.
Alternatively, just close the PR.